### PR TITLE
Add safe navigation to allow view to render when missing shipping rates

### DIFF
--- a/solidus_bootstrap/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/shared/_order_details.html.erb
@@ -21,7 +21,7 @@
           <% order.shipments.each do |shipment| %>
             <div>
               <i class='fa fa-truck'></i>
-              <%= Spree.t(:shipment_details, :stock_location => shipment.stock_location.name, :shipping_method => shipment.selected_shipping_rate.name) %>
+              <%= Spree.t(:shipment_details, :stock_location => shipment.stock_location.name, :shipping_method => shipment.selected_shipping_rate&.name) %>
             </div>
           <% end %>
         </div>


### PR DESCRIPTION
The `selected_shipping_rate` is sometimes missing on shipments, adding safe navigation here allows the view to be rendered even in this case.

This can prevent these [order show errors](https://alarmgrid.airbrake.io/projects/141883/groups/2652243500835519055/notices/2669301997076148854?dur=90d%2F1d&last_n=30&tab=notice-detail) from occurring.