### PR TITLE
Add safe navigation to shipping rate in order details partial

### DIFF
--- a/solidus_bootstrap/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/shared/_order_details.html.erb
@@ -107,7 +107,7 @@
   <% end %>
 
   <tfoot id='shipment-total'>
-    <% order.shipments.group_by { |s| s.selected_shipping_rate.name }.each do |name, shipments| %>
+    <% order.shipments.group_by { |s| s.selected_shipping_rate&.name }.each do |name, shipments| %>
       <tr class="total" data-hook='shipment-row'>
         <td colspan="4" align="right" class="text-muted"><%= Spree.t(:shipping) %>: <strong><%= name %></strong></td>
         <td class="total"><span><%= Spree::Money.new(shipments.sum(&:discounted_cost), currency: order.currency).to_html %></span></td>


### PR DESCRIPTION
The selected_shipping_rate is sometimes missing on shipments, adding safe navigation here allows the view to be rendered even in this case.
Another reference was [previously updated](https://github.com/alarmgrid/solidus_bootstrap_frontend/pull/3), but this second call was missed.

A [new error](https://alarmgrid.airbrake.io/projects/141883/groups/2673754655005323846?dur=90d%2F1d&last_n=90&filters=%7B%22order%22%3A%22last_notice%22%2C%22resolved%22%3A%22any%22%7D&tab=overview) is associated with this error.