### PR TITLE
Update i18n calls to support Solidus 2.8

### DIFF
--- a/solidus_auth_devise_bootstrap/lib/views/frontend/spree/checkout/registration.html.erb
+++ b/solidus_auth_devise_bootstrap/lib/views/frontend/spree/checkout/registration.html.erb
@@ -1,5 +1,5 @@
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @user } %>
-<h1><%= Spree.t(:registration) %></h1>
+<h1><%= I18n.t("spree.registration") %></h1>
 <div id="registration" class="row" data-hook>
   <div id="account">
     <%= render template: 'spree/user_sessions/new' %>
@@ -8,7 +8,7 @@
     <div class="col-md-6">
       <div class="panel panel-default">
         <div class="panel-heading">
-          <h3 class="panel-title"><%= Spree.t(:guest_user_account) %></h3>
+          <h3 class="panel-title"><%= I18n.t("spree.guest_user_account") %></h3>
         </div>
         <div id="guest_checkout" class="panel-body" data-hook>
           <% if flash[:registration_error] %>
@@ -16,9 +16,9 @@
           <% end %>
           <%= form_for @order, :url => update_checkout_registration_path, :method => :put, :html => { :id => 'checkout_form_registration' } do |f| %>
             <p>
-              <%= f.email_field :email, :class => 'form-control title', :placeholder => Spree.t(:email) %>
+              <%= f.email_field :email, :class => 'form-control title', :placeholder => I18n.t("spree.email") %>
             </p>
-            <p><%= f.submit Spree.t(:continue), :class => 'btn btn-lg btn-success btn-block' %></p>
+            <p><%= f.submit I18n.t("spree.continue"), :class => 'btn btn-lg btn-success btn-block' %></p>
           <% end %>
         </div>
       </div>

--- a/solidus_auth_devise_bootstrap/lib/views/frontend/spree/shared/_login.html.erb
+++ b/solidus_auth_devise_bootstrap/lib/views/frontend/spree/shared/_login.html.erb
@@ -1,19 +1,19 @@
 <%= form_for Spree::User.new, :as => :spree_user, :url => spree.create_new_session_path do |f| %>
   <fieldset id="password-credentials">
     <div class="form-group">
-      <%= f.email_field :email, :class => 'form-control', :tabindex => 1, :placeholder => Spree.t(:email) %>
+      <%= f.email_field :email, :class => 'form-control', :tabindex => 1, :placeholder => I18n.t("spree.email") %>
     </div>
     <div class="form-group">
-      <%= f.password_field :password, :class => 'form-control', :tabindex => 2, :placeholder => Spree.t(:password) %>
+      <%= f.password_field :password, :class => 'form-control', :tabindex => 2, :placeholder => I18n.t("spree.password") %>
     </div>
     <div class="checkbox">
       <label>
         <%= f.check_box :remember_me %>
-        <%= f.label :remember_me, Spree.t(:remember_me) %>
+        <%= f.label :remember_me, I18n.t("spree.remember_me") %>
       </label>
     </div>
     <div class="form-group">
-      <%= f.submit Spree.t(:login), :class => 'btn btn-lg btn-success btn-block', :tabindex => 3 %>
+      <%= f.submit I18n.t("spree.login"), :class => 'btn btn-lg btn-success btn-block', :tabindex => 3 %>
     </div>
   </fieldset>
 <% end %>

--- a/solidus_auth_devise_bootstrap/lib/views/frontend/spree/shared/_login_bar.html.erb
+++ b/solidus_auth_devise_bootstrap/lib/views/frontend/spree/shared/_login_bar.html.erb
@@ -1,6 +1,6 @@
 <% if spree_current_user %>
-  <li><%= link_to Spree.t(:my_account), spree.account_path %></li>
-  <li><%= link_to Spree.t(:logout), spree.logout_path %></li>
+  <li><%= link_to I18n.t("spree.my_account"), spree.account_path %></li>
+  <li><%= link_to I18n.t("spree.logout"), spree.logout_path %></li>
 <% else %>
-  <li id="link-to-login"><%= link_to Spree.t(:login), spree.login_path %></li>
+  <li id="link-to-login"><%= link_to I18n.t("spree.login"), spree.login_path %></li>
 <% end %>

--- a/solidus_auth_devise_bootstrap/lib/views/frontend/spree/shared/_user_form.html.erb
+++ b/solidus_auth_devise_bootstrap/lib/views/frontend/spree/shared/_user_form.html.erb
@@ -1,13 +1,13 @@
 <fieldset id="password-credentials">
   <div class="form-group">
-    <%= f.email_field :email, :class => 'form-control', :placeholder => Spree.t(:email) %>
+    <%= f.email_field :email, :class => 'form-control', :placeholder => I18n.t("spree.email") %>
   </div>
   <hr />
   <div class="form-group">
-    <%= f.password_field :password, :class => 'form-control', :placeholder => Spree.t(:password) %>
+    <%= f.password_field :password, :class => 'form-control', :placeholder => I18n.t("spree.password") %>
   </div> 
   <div class="form-group">
-    <%= f.password_field :password_confirmation, :class => 'form-control', :placeholder => Spree.t(:confirm_password) %>
+    <%= f.password_field :password_confirmation, :class => 'form-control', :placeholder => I18n.t("spree.confirm_password") %>
   </div> 
 </fieldset>
 <div data-hook="signup_below_password_fields"></div>

--- a/solidus_auth_devise_bootstrap/lib/views/frontend/spree/user_passwords/edit.html.erb
+++ b/solidus_auth_devise_bootstrap/lib/views/frontend/spree/user_passwords/edit.html.erb
@@ -2,20 +2,20 @@
 <div class="col-md-6 col-md-offset-3">
   <div class="panel panel-default">
     <div class="panel-heading">
-      <h3 class="panel-title"><%= Spree.t(:change_my_password) %></h3>
+      <h3 class="panel-title"><%= I18n.t("spree.change_my_password") %></h3>
     </div>
     <div class="panel-body">
       <%= form_for @spree_user, :as => :spree_user, :url => spree.update_password_path, :method => :put do |f| %>
         <p>
-          <%= f.label :password, Spree.t(:password) %><br />
+          <%= f.label :password, I18n.t("spree.password") %><br />
           <%= f.password_field :password, :class => "form-control" %><br />
         </p>
         <p>
-          <%= f.label :password_confirmation, Spree.t(:confirm_password) %><br />
+          <%= f.label :password_confirmation, I18n.t("spree.confirm_password") %><br />
           <%= f.password_field :password_confirmation, :class => "form-control" %><br />
         </p>
         <%= f.hidden_field :reset_password_token %>
-        <%= f.submit Spree.t(:update), :class => 'btn btn-lg btn-success btn-block' %>
+        <%= f.submit I18n.t("spree.update"), :class => 'btn btn-lg btn-success btn-block' %>
       <% end %>
     </div>
   </div>

--- a/solidus_auth_devise_bootstrap/lib/views/frontend/spree/user_passwords/new.html.erb
+++ b/solidus_auth_devise_bootstrap/lib/views/frontend/spree/user_passwords/new.html.erb
@@ -2,18 +2,18 @@
 <div class="col-md-6 col-md-offset-3" id="forgot-password">
   <div class="panel panel-default">
     <div class="panel-heading">
-      <h3 class="panel-title"><%= Spree.t(:forgot_password) %></h3>
+      <h3 class="panel-title"><%= I18n.t("spree.forgot_password") %></h3>
     </div>
     <div class="panel-body">
-      <p><%= Spree.t(:instructions_to_reset_password) %></p>
+      <p><%= I18n.t("spree.instructions_to_reset_password") %></p>
 
       <%= form_for Spree::User.new, :as => :spree_user, :url => spree.reset_password_path do |f| %>
         <p>
-          <%= f.label :email, Spree.t(:email) %><br />
+          <%= f.label :email, I18n.t("spree.email") %><br />
           <%= f.email_field :email, :class => "form-control" %>
         </p>
         <p>
-          <%= f.submit Spree.t(:reset_password), :class => 'btn btn-lg btn-success btn-block' %>
+          <%= f.submit I18n.t("spree.reset_password"), :class => 'btn btn-lg btn-success btn-block' %>
         </p>
       <% end %>
     </div>

--- a/solidus_auth_devise_bootstrap/lib/views/frontend/spree/user_registrations/new.html.erb
+++ b/solidus_auth_devise_bootstrap/lib/views/frontend/spree/user_registrations/new.html.erb
@@ -3,18 +3,18 @@
 <div class="col-md-6 col-md-offset-3">
   <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title"><%= Spree.t(:new_customer) %></h3>
+        <h3 class="panel-title"><%= I18n.t("spree.new_customer") %></h3>
     </div>
       <div id="new-customer" class="panel-body" data-hook="login">
           <%= form_for resource, :as => :spree_user, :url => spree.registration_path(@user) do |f| %>
             <div data-hook="signup_inside_form">
               <%= render :partial => 'spree/shared/user_form', :locals => { :f => f } %>
-              <p><%= f.submit Spree.t(:create), :class => 'btn btn-lg btn-success btn-block' %></p>
+              <p><%= f.submit I18n.t("spree.create"), :class => 'btn btn-lg btn-success btn-block' %></p>
             </div>
           <% end %>
           <div class="text-center">
-            <%= Spree.t(:or) %> 
-              <%= link_to Spree.t(:login_as_existing), spree.login_path %>
+            <%= I18n.t("spree.or") %> 
+              <%= link_to I18n.t(:login_as_existing), spree.login_path %>
           </div>
           <div data-hook="login_extras"></div>
       </div>

--- a/solidus_auth_devise_bootstrap/lib/views/frontend/spree/user_sessions/new.html.erb
+++ b/solidus_auth_devise_bootstrap/lib/views/frontend/spree/user_sessions/new.html.erb
@@ -2,7 +2,7 @@
 <div class="col-md-6 <%= request.path == spree.login_path ? "col-md-offset-3" : "" %>">
   <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title"><%= Spree.t(:login_as_existing) %></h3>
+        <h3 class="panel-title"><%= I18n.t("spree.login_as_existing") %></h3>
     </div>
       <div id="existing-customer" class="panel-body" data-hook="login">
           <% if flash[:alert] %>
@@ -10,9 +10,9 @@
           <% end %>
           <%= render :partial => 'spree/shared/login' %>
           <div class="text-center">
-            <%= Spree.t(:or) %>
-                <%= link_to Spree.t(:create_a_new_account), spree.signup_path %> |
-                <%= link_to Spree.t(:forgot_password), spree.recover_password_path %>
+            <%= I18n.t("spree.or") %>
+                <%= link_to I18n.t("spree.create_a_new_account"), spree.signup_path %> |
+                <%= link_to I18n.t("spree.forgot_password"), spree.recover_password_path %>
           </div>
           <div data-hook="login_extras"></div>
       </div>

--- a/solidus_auth_devise_bootstrap/lib/views/frontend/spree/users/edit.html.erb
+++ b/solidus_auth_devise_bootstrap/lib/views/frontend/spree/users/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="col-md-6 col-md-offset-3">
   <div class="panel panel-default">
     <div class="panel-heading">
-      <h3 class="panel-title"><%= Spree.t(:editing_user) %></h3>
+      <h3 class="panel-title"><%= I18n.t("spree.editing_user") %></h3>
     </div>
     <div class="panel-body">
       <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @user } %>
@@ -9,7 +9,7 @@
       <%= form_for Spree::User.new, :as => @user, :url => spree.user_path(@user), :method => :put do |f| %>
         <%= render :partial => 'spree/shared/user_form', :locals => { :f => f } %>
         <p>
-          <%= f.submit Spree.t(:update), :class => 'btn btn-primary' %>
+          <%= f.submit I18n.t("spree.update"), :class => 'btn btn-primary' %>
         </p>
       <% end %>
     </div>

--- a/solidus_auth_devise_bootstrap/lib/views/frontend/spree/users/show.html.erb
+++ b/solidus_auth_devise_bootstrap/lib/views/frontend/spree/users/show.html.erb
@@ -2,24 +2,24 @@
 
 <div data-hook="account_summary" class="account-summary well">
   <dl id="user-info">
-    <dt><%= Spree.t(:email) %></dt>
-    <dd><%= @user.email %> (<%= link_to Spree.t(:edit), spree.edit_account_path %>)</dd>
+    <dt><%= I18n.t("spree.email") %></dt>
+    <dd><%= @user.email %> (<%= link_to I18n.t("spree.edit"), spree.edit_account_path %>)</dd>
   </dl>
 </div>
 
 <div data-hook="account_my_orders" class="account-my-orders">
 
-  <h3><%= Spree.t(:my_orders) %></h3>
+  <h3><%= I18n.t("spree.my_orders") %></h3>
   <% if @orders.present? %>
     <table class="table table-striped order-summary">
       <thead class="active">
       <tr>
-        <th class="order-number"><%= I18n.t(:number, :scope => 'activerecord.attributes.spree/order') %></th>
-        <th class="order-date"><%= Spree.t(:date) %></th>
-        <th class="order-status"><%= Spree.t(:status) %></th>
-        <th class="order-payment-state"><%= Spree.t(:payment_state) %></th>
-        <th class="order-shipment-state"><%= Spree.t(:shipment_state) %></th>
-        <th class="order-total"><%= Spree.t(:total) %></th>
+        <th class="order-number"><%= I18n.t("number", scope: 'activerecord.attributes.spree/order') %></th>
+        <th class="order-date"><%= I18n.t("spree.date") %></th>
+        <th class="order-status"><%= I18n.t("spree.status") %></th>
+        <th class="order-payment-state"><%= I18n.t("spree.payment_state") %></th>
+        <th class="order-shipment-state"><%= I18n.t("spree.shipment_state") %></th>
+        <th class="order-total"><%= I18n.t("spree.total") %></th>
       </tr>
       </thead>
       <tbody>
@@ -27,16 +27,16 @@
         <tr>
           <td class="order-number"><%= link_to order.number, order_url(order) %></td>
           <td class="order-date"><%= l order.completed_at.to_date %></td>
-          <td class="order-status"><%= Spree.t("order_state.#{order.state}").titleize %></td>
-          <td class="order-payment-state"><%= Spree.t("payment_states.#{order.payment_state}").titleize if order.payment_state %></td>
-          <td class="order-shipment-state"><%= Spree.t("shipment_states.#{order.shipment_state}").titleize if order.shipment_state %></td>
+          <td class="order-status"><%= I18n.t("spree.order_state.#{order.state}").titleize %></td>
+          <td class="order-payment-state"><%= I18n.t("spree.payment_states.#{order.payment_state}").titleize if order.payment_state %></td>
+          <td class="order-shipment-state"><%= I18n.t("spree.shipment_states.#{order.shipment_state}").titleize if order.shipment_state %></td>
           <td class="lead text-primary order-total"><%= order.display_total %></td>
         </tr>
       <% end %>
       </tbody>
     </table>
   <% else %>
-    <div class="alert alert-info"><%= Spree.t(:you_have_no_orders_yet) %></div>
+    <div class="alert alert-info"><%= I18n.t("spree.you_have_no_orders_yet") %></div>
   <% end %>
   <br />
 

--- a/solidus_bootstrap/core/app/helpers/spree/base_helper_decorator.rb
+++ b/solidus_bootstrap/core/app/helpers/spree/base_helper_decorator.rb
@@ -11,11 +11,11 @@ Spree::BaseHelper.class_eval do
   end
 
   def link_to_cart(text = nil)
-    text = text ? h(text) : Spree.t('cart')
+    text = text ? h(text) : I18n.t('spree.cart')
     css_class = nil
 
     if current_order.nil? || current_order.item_count.zero?
-      text = "<span class='glyphicon glyphicon-shopping-cart'></span> #{text}: (#{Spree.t('empty')})"
+      text = "<span class='glyphicon glyphicon-shopping-cart'></span> #{text}: (#{I18n.t('spree.empty')})"
       css_class = 'empty'
     else
       text = "<span class='glyphicon glyphicon-shopping-cart'></span> #{text}: (#{current_order.item_count})  <span class='amount'>#{current_order.display_total.to_html}</span>"
@@ -79,14 +79,14 @@ Spree::BaseHelper.class_eval do
   def breadcrumbs(taxon, separator="&nbsp;", breadcrumb_class="breadcrumb")
     return "" if current_page?("/") || taxon.nil?
 
-    crumbs = [[Spree.t(:home), spree.root_path]]
+    crumbs = [[I18n.t("spree.home"), spree.root_path]]
 
     if taxon
-      crumbs << [Spree.t(:products), products_path]
+      crumbs << [I18n.t("spree.products"), products_path]
       crumbs += taxon.ancestors.collect { |a| [a.name, spree.nested_taxons_path(a.permalink)] } unless taxon.ancestors.empty?
       crumbs << [taxon.name, spree.nested_taxons_path(taxon.permalink)]
     else
-      crumbs << [Spree.t(:products), products_path]
+      crumbs << [I18n.t("spree.products"), products_path]
     end
 
     separator = raw(separator)
@@ -122,7 +122,7 @@ Spree::BaseHelper.class_eval do
     end
 
     countries.collect do |country|
-      country.name = Spree.t(country.iso, scope: 'country_names', default: country.name)
+      country.name = I18n.t("spree.country_names.#{country.iso}", default: country.name)
       country
     end.sort_by { |c| c.name.parameterize }
   end

--- a/solidus_bootstrap/core/app/helpers/spree/checkout_helper.rb
+++ b/solidus_bootstrap/core/app/helpers/spree/checkout_helper.rb
@@ -7,7 +7,7 @@ module Spree
     def checkout_progress
       states = checkout_states
       items = states.map do |state|
-        text = Spree.t("order_state.#{state}").titleize
+        text = I18n.t("spree.order_state.#{state}").titleize
 
         css_classes = []
         current_index = states.index(@order.state)

--- a/solidus_bootstrap/frontend/app/views/spree/address/_form.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/address/_form.html.erb
@@ -1,33 +1,33 @@
 <% address_id = address_type.chars.first %>
 <div class="inner" data-hook=<%="#{address_type}_inner" %>>
   <p class="field" id=<%="#{address_id}firstname" %>>
-    <%= form.label :firstname, Spree.t(:first_name) %><span class="required">*</span><br />
+    <%= form.label :firstname, I18n.t("spree.first_name") %><span class="required">*</span><br />
     <%= form.text_field :firstname, :class => 'form-control required' %>
   </p>
   <p class="field" id=<%="#{address_id}lastname" %>>
-    <%= form.label :lastname, Spree.t(:last_name) %><span class="required">*</span><br />
+    <%= form.label :lastname, I18n.t("spree.last_name") %><span class="required">*</span><br />
     <%= form.text_field :lastname, :class => 'form-control required' %>
   </p>
   <% if Spree::Config[:company] %>
     <p class="field" id=<%="#{address_id}company" %>>
-      <%= form.label :company, Spree.t(:company) %><br />
+      <%= form.label :company, I18n.t("spree.company") %><br />
       <%= form.text_field :company, :class => 'form-control' %>
     </p>
   <% end %>
   <p class="field" id=<%="#{address_id}address1" %>>
-    <%= form.label :address1, Spree.t(:street_address) %><span class="required">*</span><br />
+    <%= form.label :address1, I18n.t("spree.street_address") %><span class="required">*</span><br />
     <%= form.text_field :address1, :class => 'form-control  required' %>
   </p>
   <p class="field" id=<%="#{address_id}address2" %>>
-    <%= form.label :address2, Spree.t(:street_address_2) %><br />
+    <%= form.label :address2, I18n.t("spree.street_address_2") %><br />
     <%= form.text_field :address2, :class => 'form-control' %>
   </p>
   <p class="field" id=<%="#{address_id}city" %>>
-    <%= form.label :city, Spree.t(:city) %><span class="required">*</span><br />
+    <%= form.label :city, I18n.t("spree.city") %><span class="required">*</span><br />
     <%= form.text_field :city, :class => 'form-control required' %>
   </p>
   <p class="field" id=<%="#{address_id}country" %>>
-    <%= form.label :country_id, Spree.t(:country) %><span class="required">*</span><br />
+    <%= form.label :country_id, I18n.t("spree.country") %><span class="required">*</span><br />
     <span id=<%="#{address_id}country-selection" %>>
       <%= form.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'form-control required'} %>
     </span>
@@ -36,7 +36,7 @@
   <% if Spree::Config[:address_requires_state] %>
     <p class="field" id=<%="#{address_id}state" %>>
       <% have_states = !address.country.states.empty? %>
-      <%= form.label :state, Spree.t(:state) %><span class='required' id=<%="#{address_id}state-required"%>>*</span><br/>
+      <%= form.label :state, I18n.t("spree.state") %><span class='required' id=<%="#{address_id}state-required"%>>*</span><br/>
 
       <% state_elements = [
          form.collection_select(:state_id, address.country.states,
@@ -59,16 +59,16 @@
   <% end %>
 
   <p class="field" id=<%="#{address_id}zipcode" %>>
-    <%= form.label :zipcode, Spree.t(:zip) %><% if address.require_zipcode? %><span class="required">*</span><br /><% end %>
+    <%= form.label :zipcode, I18n.t("spree.zip") %><% if address.require_zipcode? %><span class="required">*</span><br /><% end %>
     <%= form.text_field :zipcode, :class => "form-control #{'required' if address.require_zipcode?}" %>
   </p>
   <p class="field" id=<%="#{address_id}phone" %>>
-    <%= form.label :phone, Spree.t(:phone) %><% if address.require_phone? %><span class="required">*</span><br /><% end %>
+    <%= form.label :phone, I18n.t("spree.phone") %><% if address.require_phone? %><span class="required">*</span><br /><% end %>
     <%= form.phone_field :phone, :class => "form-control #{'required' if address.require_phone?}" %>
   </p>
   <% if Spree::Config[:alternative_shipping_phone] %>
     <p class="field" id=<%="#{address_id}altphone" %>>
-      <%= form.label :alternative_phone, Spree.t(:alternative_phone) %><br />
+      <%= form.label :alternative_phone, I18n.t("spree.alternative_phone") %><br />
       <%= form.phone_field :alternative_phone, :class => 'form-control' %>
     </p>
   <% end %>

--- a/solidus_bootstrap/frontend/app/views/spree/checkout/_address.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/checkout/_address.html.erb
@@ -3,7 +3,7 @@
     <div class="panel panel-default" id="billing" data-hook>
       <%= form.fields_for :bill_address do |bill_form| %>
         <div class="panel-heading">
-          <h3 class="panel-title"><%= Spree.t(:billing_address) %></h3>
+          <h3 class="panel-title"><%= I18n.t("spree.billing_address") %></h3>
         </div>
         <div class="panel-body">
           <%= render :partial => 'spree/address/form', :locals => { :form => bill_form, :address_type => 'billing', :address => @order.bill_address } %>
@@ -16,13 +16,13 @@
     <div class="panel panel-default" id="shipping" data-hook>
       <%= form.fields_for :ship_address do |ship_form| %>
         <div class="panel-heading">
-          <h3 class="panel-title"><%= Spree.t(:shipping_address) %></h3>
+          <h3 class="panel-title"><%= I18n.t("spree.shipping_address") %></h3>
         </div>
         <div class="panel-body">
           <p class="field checkbox" data-hook="use_billing">
             <%= label_tag :order_use_billing, :id => 'use_billing' do %>
               <%= check_box_tag 'order[use_billing]', '1', @order.shipping_eq_billing_address? %>
-              <%= Spree.t(:use_billing_address) %>
+              <%= I18n.t("spree.use_billing_address") %>
             <% end %>
           </p>
           <%= render :partial => 'spree/address/form', :locals => { :form => ship_form, :address_type => 'shipping', :address => @order.ship_address } %>
@@ -33,12 +33,12 @@
 </div>
 
 <div class="well text-right form-buttons" data-hook="buttons">
-  <%= submit_tag Spree.t(:save_and_continue), :class => 'btn btn-lg btn-success' %>
+  <%= submit_tag I18n.t("spree.save_and_continue"), :class => 'btn btn-lg btn-success' %>
   <% if try_spree_current_user %>
     <span data-hook="save_user_address">
       &nbsp; &nbsp;
       <%= check_box_tag 'save_user_address', '1', try_spree_current_user.respond_to?(:persist_order_address) %>
-      <%= label_tag :save_user_address, Spree.t(:save_my_address) %>
+      <%= label_tag :save_user_address, I18n.t("spree.save_my_address") %>
     </span>
   <% end %>
 </div>

--- a/solidus_bootstrap/frontend/app/views/spree/checkout/_confirm.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/checkout/_confirm.html.erb
@@ -1,6 +1,6 @@
 <div class="panel panel-default" id="order_details" data-hook>
   <div class="panel-heading">
-    <h3 class="panel-title"><%= Spree.t(:confirm) %></h3>
+    <h3 class="panel-title"><%= I18n.t("spree.confirm") %></h3>
   </div>
   <div class="panel-body">
 	<%= render :partial => 'spree/shared/order_details', :locals => { :order => @order } %>
@@ -8,6 +8,6 @@
 </div>
 
 <div class="well text-right form-buttons" data-hook="buttons">
-  <%= submit_tag Spree.t(:place_order), :class => 'btn btn-lg btn-success' %>
+  <%= submit_tag I18n.t("spree.place_order"), :class => 'btn btn-lg btn-success' %>
   <script>Spree.disableSaveOnClick();</script>
 </div>

--- a/solidus_bootstrap/frontend/app/views/spree/checkout/_delivery.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/checkout/_delivery.html.erb
@@ -1,6 +1,6 @@
 <div class="panel panel-default" id='shipping_method' data-hook>
   <div class="panel-heading">
-    <h3 class="panel-title"><%= Spree.t(:delivery) %></h3>
+    <h3 class="panel-title"><%= I18n.t("spree.delivery") %></h3>
   </div>
   <div class="panel-body" data-hook="shipping_method_inner">
     <div id="methods">
@@ -8,7 +8,7 @@
 
         <div class="shipment">
           <h4 class="stock-location" data-hook="stock-location">
-            <%= Spree.t(:package_from) %>
+            <%= I18n.t("spree.package_from") %>
             <strong class="stock-location-name" data-hook="stock-location-name"><%= ship_form.object.stock_location.name %></strong>
           </h4>
 
@@ -22,9 +22,9 @@
             <thead>
               <tr class="active">
                 <th></th>
-                <th align='left'><%= Spree.t(:item) %></th>
-                <th><%= Spree.t(:qty) %></th>
-                <th><%= Spree.t(:price) %></th>
+                <th align='left'><%= I18n.t("spree.item") %></th>
+                <th><%= I18n.t("spree.qty") %></th>
+                <th><%= I18n.t("spree.price") %></th>
               </tr>
             </thead>
             <tbody>
@@ -39,7 +39,7 @@
             </tbody>
           </table>
 
-          <h4 class="stock-shipping-method-title"><%= Spree.t(:shipping_method) %></h4>
+          <h4 class="stock-shipping-method-title"><%= I18n.t("spree.shipping_method") %></h4>
           <ul class="list-group shipping-methods">
             <% ship_form.object.shipping_rates.each do |rate| %>
               <li class="list-group-item shipping-method">
@@ -58,7 +58,7 @@
       <% if @differentiator.try(:missing?) %>
         <div class="shipment unshippable">
           <h3 class="stock-location" data-hook="stock-location">
-            <%= Spree.t(:unshippable_items) %>
+            <%= I18n.t("spree.unshippable_items") %>
           </h3>
           <table class="table stock-contents" data-hook="stock-missing">
             <colgroup>
@@ -69,9 +69,9 @@
             </colgroup>
             <thead>
               <th></th>
-              <th align='left'><%= Spree.t(:item) %></th>
-              <th><%= Spree.t(:qty) %></th>
-              <th><%= Spree.t(:price) %></th>
+              <th align='left'><%= I18n.t("spree.item") %></th>
+              <th><%= I18n.t("spree.qty") %></th>
+              <th><%= I18n.t("spree.price") %></th>
             </thead>
             <tbody>
               <% @differentiator.missing.each do |variant, quantity| %>
@@ -90,7 +90,7 @@
     </div>
     <% if Spree::Config[:shipping_instructions] %>
       <p id="minstrs" data-hook>
-        <h4><%= Spree.t(:shipping_instructions) %></h4>
+        <h4><%= I18n.t("spree.shipping_instructions") %></h4>
         <%= form.text_area :special_instructions, :cols => 40, :rows => 4, :class => "form-control" %>
       </p>
     <% end %>
@@ -100,5 +100,5 @@
 <br />
 
 <div class="well text-right form-buttons" data-hook="buttons">
-  <%= submit_tag Spree.t(:save_and_continue), :class => 'btn btn-lg btn-success' %>
+  <%= submit_tag I18n.t("spree.save_and_continue"), :class => 'btn btn-lg btn-success' %>
 </div>

--- a/solidus_bootstrap/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/checkout/_payment.html.erb
@@ -1,6 +1,6 @@
 <div class="panel panel-default" id="payment" data-hook>
   <div class="panel-heading">
-    <h3 class="panel-title"><%= Spree.t(:payment_information) %></h3>
+    <h3 class="panel-title"><%= I18n.t("spree.payment_information") %></h3>
   </div>
   <div class="panel-body" data-hook="checkout_payment_step">
 
@@ -39,7 +39,7 @@
       <li class="list-group-item">
         <label>
           <%= radio_button_tag "order[payments_attributes][][payment_method_id]", method.id, method == @order.available_payment_methods.first %>
-          <%= Spree.t(method.name, :scope => :payment_methods, :default => method.name) %>
+          <%= I18n.t("spree.payment_methods.#{method.name}", default: method.name) %>
         </label>
       </li>
       <% end %>
@@ -63,6 +63,6 @@
 </div>
 
 <div class="well text-right form-buttons" data-hook="buttons">
-  <%= submit_tag Spree.t(:save_and_continue), class: 'btn btn-lg btn-success primary' %>
+  <%= submit_tag I18n.t("spree.save_and_continue"), class: 'btn btn-lg btn-success primary' %>
   <script>Spree.disableSaveOnClick();</script>
 </div>

--- a/solidus_bootstrap/frontend/app/views/spree/checkout/_summary.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/checkout/_summary.html.erb
@@ -1,9 +1,9 @@
-<h3><%= Spree.t(:order_summary) %></h3>
+<h3><%= I18n.t("spree.order_summary") %></h3>
 
 <table class="table" data-hook="order_summary">
   <tbody>
     <tr data-hook="item_total">
-      <td><strong><%= Spree.t(:item_total) %>:</strong></td>
+      <td><strong><%= I18n.t("spree.item_total") %>:</strong></td>
       <td><strong><%= order.display_item_total.to_html %></strong></td>
     </tr>
 
@@ -29,7 +29,7 @@
 
     <% if order.passed_checkout_step?("delivery") && order.shipments.any? %>
       <tr data-hook="shipping_total">
-        <td><%= Spree.t(:shipping_total) %>:</td>
+        <td><%= I18n.t("spree.shipping_total") %>:</td>
         <td><%= Spree::Money.new(order.shipments.to_a.sum(&:cost), currency: order.currency).to_html %></td>
       </tr>
 
@@ -58,7 +58,7 @@
     <% end %>
 
     <tr data-hook="order_total">
-      <td><strong><%= Spree.t(:order_total) %>:</strong></td>
+      <td><strong><%= I18n.t("spree.order_total") %>:</strong></td>
       <td><strong><span id='summary-order-total' class="lead text-primary"><%= order.display_total.to_html %></span></strong></td>
     </tr>
   </tbody>

--- a/solidus_bootstrap/frontend/app/views/spree/checkout/edit.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/checkout/edit.html.erb
@@ -3,7 +3,7 @@
 
   <div class="row" data-hook="checkout_header">
     <div class="col-sm-3">
-      <h1 data-hook="checkout_title"><%= Spree.t(:checkout) %></h1>
+      <h1 data-hook="checkout_title"><%= I18n.t("spree.checkout") %></h1>
     </div>
     <div class="col-sm-9" data-hook="checkout_progress"><%= checkout_progress %></div>
   </div>

--- a/solidus_bootstrap/frontend/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/checkout/payment/_gateway.html.erb
@@ -3,30 +3,30 @@
   <% param_prefix = "payment_source[#{payment_method.id}]" %>
 
   <p class="field">
-    <%= label_tag "name_on_card_#{payment_method.id}", Spree.t(:name_on_card) %><span class="required">*</span><br />
+    <%= label_tag "name_on_card_#{payment_method.id}", I18n.t("spree.name_on_card") %><span class="required">*</span><br />
     <%= text_field_tag "#{param_prefix}[name]", "#{@order.billing_firstname} #{@order.billing_lastname}", { id: "name_on_card_#{payment_method.id}", :class => 'form-control required'} %>
   </p>
 
   <p class="field" data-hook="card_number">
-    <%= label_tag "card_number", Spree.t(:card_number) %><span class="required">*</span><br />
+    <%= label_tag "card_number", I18n.t("spree.card_number") %><span class="required">*</span><br />
     <% options_hash = Rails.env.production? ? {:autocomplete => 'off'} : {} %>
     <%= text_field_tag "#{param_prefix}[number]", '', options_hash.merge(:id => 'card_number', :class => 'form-control required cardNumber', :size => 19, :maxlength => 19, :autocomplete => "off") %>
     &nbsp;
     <span id="card_type" style="display:none;">
-      ( <span id="looks_like" ><%= Spree.t(:card_type_is) %> <span id="type"></span></span>
-        <span id="unrecognized"><%= Spree.t(:unrecognized_card_type) %></span>
+      ( <span id="looks_like" ><%= I18n.t("spree.card_type_is") %> <span id="type"></span></span>
+        <span id="unrecognized"><%= I18n.t("spree.unrecognized_card_type") %></span>
       )
     </span>
   </p>
   <div class="row">
     <div class="col-md-8 field" data-hook="card_expiration">
-      <%= label_tag "card_expiry", Spree.t(:expiration) %><span class="required">*</span><br />
+      <%= label_tag "card_expiry", I18n.t("spree.expiration") %><span class="required">*</span><br />
       <%= text_field_tag "#{param_prefix}[expiry]", '', :id => 'card_expiry', :class => "form-control required cardExpiry", :placeholder => "MM / YY" %>
     </div>
     <div class="col-md-4 field" data-hook="card_code">
-      <%= label_tag "card_code", Spree.t(:card_code) %><span class="required">*</span><br />
+      <%= label_tag "card_code", I18n.t("spree.card_code") %><span class="required">*</span><br />
       <%= text_field_tag "#{param_prefix}[verification_value]", '', options_hash.merge(:id => 'card_code', :class => 'form-control required cardCode', :size => 5) %>
-      <%= link_to "(#{Spree.t(:what_is_this)})", spree.cvv_path, :target => '_blank', "data-hook" => "cvv_link", :id => "cvv_link" %>
+      <%= link_to "(#{I18n.t('spree.what_is_this')})", spree.cvv_path, :target => '_blank', "data-hook" => "cvv_link", :id => "cvv_link" %>
     </div>
   </div>
 

--- a/solidus_bootstrap/frontend/app/views/spree/orders/_adjustments.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/orders/_adjustments.html.erb
@@ -1,22 +1,22 @@
 <thead>
   <tr data-hook="cart_adjustments_headers">
-    <th class="cart-adjustment-header" colspan="6"><%= Spree.t(:order_adjustments) %></th>
+    <th class="cart-adjustment-header" colspan="6"><%= I18n.t("spree.order_adjustments") %></th>
   </tr>
 </thead>
 <tbody id="cart_adjustments" data-hook>
   <% if @order.line_item_adjustments.exists? %>
     <% @order.line_item_adjustments.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
-      <%= render "spree/orders/adjustment_row", :label => label, :adjustments => adjustments, :type => Spree.t(:promotion) %>
+      <%= render "spree/orders/adjustment_row", :label => label, :adjustments => adjustments, :type => I18n.t("spree.promotion") %>
     <% end %>
   <% end %>
 
   <% @order.all_adjustments.tax.eligible.group_by(&:label).each do |label, adjustments| %>
-    <%= render "spree/orders/adjustment_row", :label => label, :adjustments => adjustments, :type => Spree.t(:tax) %>
+    <%= render "spree/orders/adjustment_row", :label => label, :adjustments => adjustments, :type => I18n.t("spree.tax") %>
   <% end %>
 
   <% @order.shipments.each do |shipment| %>
     <tr>
-      <td colspan="4" align='right'><h5><%= Spree.t(:shipping) %>: <%= shipment.shipping_method.name %></h5></td>
+      <td colspan="4" align='right'><h5><%= I18n.t("spree.shipping") %>: <%= shipment.shipping_method.name %></h5></td>
       <td colspan='2'>
         <h5><%= shipment.display_discounted_cost %></h5>
       </td>
@@ -24,6 +24,6 @@
   <% end %>
 
   <% @order.adjustments.eligible.group_by(&:label).each do |label, adjustments| %>
-    <%= render "spree/orders/adjustment_row", :label => label, :adjustments => adjustments, :type => Spree.t(:adjustment) %>
+    <%= render "spree/orders/adjustment_row", :label => label, :adjustments => adjustments, :type => I18n.t("spree.adjustment") %>
   <% end %>
 </tbody>

--- a/solidus_bootstrap/frontend/app/views/spree/orders/_form.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/orders/_form.html.erb
@@ -2,10 +2,10 @@
 <table class="table" id="cart-detail" data-hook>
   <thead>
     <tr class="active" data-hook="cart_items_headers">
-      <th class="cart-item-description-header" colspan="2"><%= Spree.t(:item) %></th>
-      <th class="cart-item-price-header"><%= Spree.t(:price) %></th>
-      <th class="cart-item-quantity-header"><%= Spree.t(:qty) %></th>
-      <th class="cart-item-total-header"><%= Spree.t(:total) %></th>
+      <th class="cart-item-description-header" colspan="2"><%= I18n.t("spree.item") %></th>
+      <th class="cart-item-price-header"><%= I18n.t("spree.price") %></th>
+      <th class="cart-item-quantity-header"><%= I18n.t("spree.qty") %></th>
+      <th class="cart-item-total-header"><%= I18n.t("spree.total") %></th>
       <th class="cart-item-delete-header"></th>
     </tr>
   </thead>
@@ -14,14 +14,14 @@
   </tbody>
   <% if @order.adjustments.nonzero.exists? || @order.line_item_adjustments.nonzero.exists? || @order.shipment_adjustments.nonzero.exists? || @order.shipments.any? %>
     <tr class="cart-subtotal">
-      <td colspan="4" align='right'><h5><%= Spree.t(:cart_subtotal, :count => @order.line_items.sum(:quantity)) %></h5></th>
+      <td colspan="4" align='right'><h5><%= I18n.t("spree.cart_subtotal", count: @order.line_items.sum(:quantity)) %></h5></th>
       <td colspan><h5><%= order_form.object.display_item_total %></h5></td>
       <td></td>
     </tr>
     <%= render "spree/orders/adjustments" %>
   <% end %>
   <tr class="warning cart-total">
-    <td colspan="4" align='right'><h5><%= Spree.t(:total) %></h5></th>
+    <td colspan="4" align='right'><h5><%= I18n.t("spree.total") %></h5></th>
     <td class="lead" colspan><%= order_form.object.display_total %></td>
     <td></td>
   </tr>

--- a/solidus_bootstrap/frontend/app/views/spree/orders/_line_item.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/orders/_line_item.html.erb
@@ -13,7 +13,7 @@
       <%= variant.options_text %>
       <% if line_item.insufficient_stock? %>
         <span class="out-of-stock">
-          <%= Spree.t(:out_of_stock) %>&nbsp;&nbsp;<br />
+          <%= I18n.t("spree.out_of_stock") %>&nbsp;&nbsp;<br />
         </span>
       <% end %>
       <span class="line-item-description" data-hook="line_item_description">

--- a/solidus_bootstrap/frontend/app/views/spree/orders/edit.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/orders/edit.html.erb
@@ -1,12 +1,12 @@
 <% @body_id = 'cart' %>
 <div data-hook="cart_container">
-  <h1><%= Spree.t(:shopping_cart) %></h1>
+  <h1><%= I18n.t("spree.shopping_cart") %></h1>
 
   <% if @order.line_items.empty? %>
 
     <div data-hook="empty_cart">
-      <div class="alert alert-info"><%= Spree.t(:your_cart_is_empty) %></div>
-      <p><%= link_to Spree.t(:continue_shopping), products_path, :class => 'btn btn-default' %></p>
+      <div class="alert alert-info"><%= I18n.t("spree.your_cart_is_empty") %></div>
+      <p><%= link_to I18n.t("spree.continue_shopping"), products_path, :class => 'btn btn-default' %></p>
     </div>
 
   <% else %>
@@ -21,12 +21,12 @@
 
           <div class="links col-md-6 navbar-form pull-right text-right" data-hook="cart_buttons">
             <div class="form-group">
-            <%= order_form.text_field :coupon_code, :size => 10, :placeholder => Spree.t(:coupon_code), class: "form-control form-control-inline" %></div>
+            <%= order_form.text_field :coupon_code, :size => 10, :placeholder => I18n.t("spree.coupon_code"), class: "form-control form-control-inline" %></div>
             <%= button_tag :class => 'btn btn-primary', :id => 'update-button' do %>
-              <%= Spree.t(:update) %>
+              <%= I18n.t("spree.update") %>
             <% end %>
             <%= button_tag :class => 'btn btn-lg btn-success', :id => 'checkout-link', :name => 'checkout' do %>
-              <%= Spree.t(:checkout) %>
+              <%= I18n.t("spree.checkout") %>
             <% end %>
           </div>
         </div>
@@ -36,9 +36,9 @@
     <div id="empty-cart" class="col-md-6 pull-left" data-hook>
       <%= form_tag empty_cart_path, :method => :put do %>
         <p id="clear_cart_link" data-hook>
-          <%= submit_tag Spree.t(:empty_cart), :class => 'btn btn-default' %>
-          <%= Spree.t(:or) %>
-          <%= link_to Spree.t(:continue_shopping), products_path, :class => 'continue' %>
+          <%= submit_tag I18n.t("spree.empty_cart"), :class => 'btn btn-default' %>
+          <%= I18n.t("spree.or") %>
+          <%= link_to I18n.t("spree.continue_shopping"), products_path, :class => 'continue' %>
         </p>
       <% end %>
     </div>

--- a/solidus_bootstrap/frontend/app/views/spree/products/_cart_form.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/products/_cart_form.html.erb
@@ -3,7 +3,7 @@
 
     <% if @product.variants_and_option_values_for(current_pricing_options).any? %>
       <div id="product-variants" class="col-md-6">
-        <h3 class="product-section-title"><%= Spree.t(:variants) %></h3>
+        <h3 class="product-section-title"><%= I18n.t("spree.variants") %></h3>
         <ul class="list-group">
           <% @product.variants_and_option_values_for(current_pricing_options).each_with_index do |variant, index| %>
             <li>
@@ -16,7 +16,7 @@
                   <span class="price diff"><%= variant_price variant %></span>
                 <% end %>
                 <% unless variant.can_supply? %>
-                  <span class="out-of-stock"><%= Spree.t(:out_of_stock) %></span>
+                  <span class="out-of-stock"><%= I18n.t("spree.out_of_stock") %></span>
                 <% end %>
               <% end %>
             </li>
@@ -31,7 +31,7 @@
       <div data-hook="product_price" class="col-md-5">
 
         <div id="product-price">
-          <h6 class="product-section-title"><%= Spree.t(:price) %></h6>
+          <h6 class="product-section-title"><%= I18n.t("spree.price") %></h6>
           <div>
             <span class="lead price selling" itemprop="price">
               <%= display_price(@product) %>
@@ -43,7 +43,7 @@
             <link itemprop="availability" href="http://schema.org/InStock" />
           <% elsif @product.variants.empty? %>
             <br />
-            <span class="out-of-stock"><%= Spree.t(:out_of_stock) %></span>
+            <span class="out-of-stock"><%= I18n.t("spree.out_of_stock") %></span>
           <% end %>
         </div>
 
@@ -53,7 +53,7 @@
             <%= number_field_tag :quantity, 1, :class => 'title form-control', :min => 1 %>
             <span class="input-group-btn">
               <%= button_tag :class => 'btn btn-success', :id => 'add-to-cart-button', :type => :submit do %>
-                <%= Spree.t(:add_to_cart) %>
+                <%= I18n.t("spree.add_to_cart") %>
               <% end %>
             </span>
           </div>
@@ -62,7 +62,7 @@
     <% else %>
         <div id="product-price">
           <br>
-          <div><span class="price selling" itemprop="price"><%= Spree.t('product_not_available_in_this_currency') %></span></div>
+          <div><span class="price selling" itemprop="price"><%= I18n.t('spree.product_not_available_in_this_currency') %></span></div>
         </div>
     <% end %>
   </div>

--- a/solidus_bootstrap/frontend/app/views/spree/products/_promotions.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/products/_promotions.html.erb
@@ -1,7 +1,7 @@
 <% promotions = @product.possible_promotions %>
 <% if promotions.any? %>
   <div id="promotions">
-    <h3><%= Spree.t(:promotions) %></h3>
+    <h3><%= I18n.t("spree.promotions") %></h3>
     <% promotions.each do |promotion| %>
     <div class="well well-sm">
       <h4><%= promotion.name %></h4>

--- a/solidus_bootstrap/frontend/app/views/spree/products/_properties.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/products/_properties.html.erb
@@ -1,5 +1,5 @@
 <% unless @product_properties.empty? %>  
-  <h3 class="product-section-title"><%= Spree.t('properties')%></h3>
+  <h3 class="product-section-title"><%= I18n.t('spree.properties')%></h3>
   <table id="product-properties" class="table table-striped" data-hook>
     <tbody>
       <% @product_properties.each do |product_property| %>

--- a/solidus_bootstrap/frontend/app/views/spree/products/_taxons.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/products/_taxons.html.erb
@@ -1,6 +1,6 @@
 <% if !@product.taxons.blank? %>
   <div id="taxon-crumbs" data-hook class=" five ">
-    <h3 class="product-section-title"><%= Spree.t(:look_for_similar_items) %></h3>
+    <h3 class="product-section-title"><%= I18n.t("spree.look_for_similar_items") %></h3>
 
     <div data-hook="product_taxons">
       <ul class="list-group" id="similar_items_by_taxon" data-hook>

--- a/solidus_bootstrap/frontend/app/views/spree/products/index.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/products/index.html.erb
@@ -15,7 +15,7 @@
 
   <div data-hook="search_results">
     <% if @products.empty? %>
-      <h6 class="search-results-title"><%= Spree.t(:no_products_found) %></h6>
+      <h6 class="search-results-title"><%= I18n.t("spree.no_products_found") %></h6>
     <% else %>
       <%= render :partial => 'spree/shared/products', :locals => { :products => @products, :taxon => @taxon } %>
     <% end %>

--- a/solidus_bootstrap/frontend/app/views/spree/products/show.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/products/show.html.erb
@@ -35,7 +35,7 @@
           <h1 class="product-title" itemprop="name"><%= @product.name %></h1>
 
           <div class="well" itemprop="description" data-hook="description">
-            <%= product_description(@product) rescue Spree.t(:product_has_no_description) %>
+            <%= product_description(@product) rescue I18n.t("spree.product_has_no_description") %>
           </div>
 
           <div id="cart-form" data-hook="cart_form">

--- a/solidus_bootstrap/frontend/app/views/spree/shared/_error_messages.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/shared/_error_messages.html.erb
@@ -1,7 +1,7 @@
 <% if target && target.errors.any? %>
   <div id="errorExplanation" class="alert alert-danger" data-hook>
-    <h3><%= Spree.t(:errors_prohibited_this_record_from_being_saved, :count => target.errors.count) %>:</h3>
-    <p><%= Spree.t(:there_were_problems_with_the_following_fields) %>:</p>
+    <h3><%= I18n.t("spree.errors_prohibited_this_record_from_being_saved", count: target.errors.count) %>:</h3>
+    <p><%= I18n.t("spree.there_were_problems_with_the_following_fields") %>:</p>
      <ul>
      <% target.errors.full_messages.each do |msg| %>
        <li><%= msg %></li>

--- a/solidus_bootstrap/frontend/app/views/spree/shared/_filters.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/shared/_filters.html.erb
@@ -22,6 +22,6 @@
         </ul>
       </div>
     <% end %>
-    <%= submit_tag Spree.t(:search), :name => nil, :class => 'btn btn-primary' %>
+    <%= submit_tag I18n.t("spree.search"), :name => nil, :class => 'btn btn-primary' %>
   <% end %>
 <% end %>

--- a/solidus_bootstrap/frontend/app/views/spree/shared/_footer.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/shared/_footer.html.erb
@@ -2,7 +2,7 @@
 	<div class="container">
 		<footer id="footer" class="row" data-hook>
 		  <div id="footer-left" class="col-md-6" data-hook>
-		    <p><%= Spree.t :powered_by  %>&nbsp;<%= link_to 'Spree', 'http://spreecommerce.com/' %></p>
+		    <p><%= I18n.t("spree.powered_by") %>&nbsp;<%= link_to 'Spree', 'http://spreecommerce.com/' %></p>
 		  </div>
 		  <div id="footer-right" class="col-md-6" data-hook></div>
 		</footer>

--- a/solidus_bootstrap/frontend/app/views/spree/shared/_main_nav_bar.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/shared/_main_nav_bar.html.erb
@@ -1,12 +1,12 @@
 <nav class="col-md-12">
   <div id="main-nav-bar" class="navbar">
     <ul class="nav navbar-nav" data-hook>
-      <li id="home-link" data-hook><%= link_to Spree.t(:home), spree.root_path %></li>
+      <li id="home-link" data-hook><%= link_to I18n.t("spree.home"), spree.root_path %></li>
     </ul>
     <ul class="nav navbar-nav navbar-right" data-hook>
       <li id="link-to-cart" data-hook>
         <noscript>
-          <%= link_to Spree.t(:cart), '/cart' %>
+          <%= link_to I18n.t("spree.cart"), '/cart' %>
         </noscript>
         &nbsp;
       </li>

--- a/solidus_bootstrap/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/shared/_order_details.html.erb
@@ -3,25 +3,25 @@
   <% if order.has_step?("address") %>
 
     <div class="col-md-3" data-hook="order-bill-address">
-      <h4><%= Spree.t(:billing_address) %> <%= link_to "(#{Spree.t(:edit)})", checkout_state_path(:address) unless @order.completed? %></h4>
+      <h4><%= I18n.t("spree.billing_address") %> <%= link_to "(#{I18n.t('spree.edit')})", checkout_state_path(:address) unless @order.completed? %></h4>
       <%= render :partial => 'spree/shared/address', :locals => { :address => order.bill_address } %>
     </div>
 
     <% if order.has_step?("delivery") %>
       <div class="col-md-3" data-hook="order-ship-address">
-        <h4><%= Spree.t(:shipping_address) %> <%= link_to "(#{Spree.t(:edit)})", checkout_state_path(:address) unless @order.completed? %></h4>
+        <h4><%= I18n.t("spree.shipping_address") %> <%= link_to "(#{I18n.t('spree.edit')})", checkout_state_path(:address) unless @order.completed? %></h4>
         <%= render :partial => 'spree/shared/address', :locals => { :address => order.ship_address } %>
       </div>
     <% end %>
 
     <% if @order.has_step?("delivery") %>
       <div class=" col-md-3">
-        <h4><%= Spree.t(:shipments) %> <%= link_to "(#{Spree.t(:edit)})", checkout_state_path(:delivery) unless @order.completed? %></h4>
+        <h4><%= I18n.t("spree.shipments") %> <%= link_to "(#{I18n.t('spree.edit')})", checkout_state_path(:delivery) unless @order.completed? %></h4>
         <div class="delivery">
           <% order.shipments.each do |shipment| %>
             <div>
               <i class='fa fa-truck'></i>
-              <%= Spree.t(:shipment_details, :stock_location => shipment.stock_location.name, :shipping_method => shipment.selected_shipping_rate&.name) %>
+              <%= I18n.t("spree.shipment_details", stock_location: shipment.stock_location.name, shipping_method: shipment.selected_shipping_rate&.name) %>
             </div>
           <% end %>
         </div>
@@ -31,7 +31,7 @@
   <% end %>
 
   <div class="col-md-3">
-    <h4><%= Spree.t(:payment_information) %> <%= link_to "(#{Spree.t(:edit)})", checkout_state_path(:payment) unless @order.completed? %></h4>
+    <h4><%= I18n.t("spree.payment_information") %> <%= link_to "(#{I18n.t('spree.edit')})", checkout_state_path(:payment) unless @order.completed? %></h4>
     <div class="payment-info">
       <% order.payments.valid.each do |payment| %>
         <%= render payment%><br/>
@@ -52,10 +52,10 @@
 
   <thead data-hook>
     <tr class="active" data-hook="order_details_line_items_headers">
-      <th colspan="2"><%= Spree.t(:item) %></th>
-      <th class="price"><%= Spree.t(:price) %></th>
-      <th class="qty"><%= Spree.t(:qty) %></th>
-      <th class="total"><span><%= Spree.t(:total) %></span></th>
+      <th colspan="2"><%= I18n.t("spree.item") %></th>
+      <th class="price"><%= I18n.t("spree.price") %></th>
+      <th class="qty"><%= I18n.t("spree.qty") %></th>
+      <th class="total"><span><%= I18n.t("spree.total") %></span></th>
     </tr>
   </thead>
 
@@ -82,14 +82,14 @@
   </tbody>
   <tfoot id="order-total" data-hook="order_details_total">
     <tr class="warning total">
-      <td colspan="4" align="right"><b><%= Spree.t(:order_total) %>:</b></td>
+      <td colspan="4" align="right"><b><%= I18n.t("spree.order_total") %>:</b></td>
       <td class="total"><span id="order_total" class="lead text-primary"><%= @order.display_total.to_html %></span></td>
     </tr>
   </tfoot>
 
   <tfoot id="subtotal" data-hook="order_details_subtotal">
     <tr class="total" id="subtotal-row">
-      <td colspan="4" align="right"><b><%= Spree.t(:subtotal) %>:</b></td>
+      <td colspan="4" align="right"><b><%= I18n.t("spree.subtotal") %>:</b></td>
       <td class="total"><span><%= @order.display_item_total.to_html %></span></td>
     </tr>
   </tfoot>
@@ -98,7 +98,7 @@
       <tfoot id="price-adjustments" data-hook="order_details_price_adjustments">
         <% order.all_adjustments.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
          <tr class="total">
-           <td colspan="4"><%= Spree.t(:promotion) %>: <strong><%= label %></strong></td>
+           <td colspan="4"><%= I18n.t("spree.promotion") %>: <strong><%= label %></strong></td>
            <td class="total"><span><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency) %></span></td>
          </tr>
        <% end %>
@@ -109,7 +109,7 @@
   <tfoot id='shipment-total'>
     <% order.shipments.group_by { |s| s.selected_shipping_rate&.name }.each do |name, shipments| %>
       <tr class="total" data-hook='shipment-row'>
-        <td colspan="4" align="right" class="text-muted"><%= Spree.t(:shipping) %>: <strong><%= name %></strong></td>
+        <td colspan="4" align="right" class="text-muted"><%= I18n.t("spree.shipping") %>: <strong><%= name %></strong></td>
         <td class="total"><span><%= Spree::Money.new(shipments.sum(&:discounted_cost), currency: order.currency).to_html %></span></td>
       </tr>
     <% end %>
@@ -119,7 +119,7 @@
     <tfoot id="tax-adjustments" data-hook="order_details_tax_adjustments">
       <% order.all_adjustments.tax.group_by(&:label).each do |label, adjustments| %>
         <tr class="total">
-          <td colspan="4" align="right" class="text-muted"><%= Spree.t(:tax) %>: <strong><%= label %></strong></td>
+          <td colspan="4" align="right" class="text-muted"><%= I18n.t("spree.tax") %>: <strong><%= label %></strong></td>
           <td class="total"><span><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency) %></span></td>
         </tr>
       <% end %>

--- a/solidus_bootstrap/frontend/app/views/spree/shared/_products.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/shared/_products.html.erb
@@ -12,11 +12,11 @@
 <div data-hook="products_search_results_heading">
   <% if products.empty? %>
     <div data-hook="products_search_results_heading_no_results_found">
-      <%= Spree.t(:no_products_found) %>
+      <%= I18n.t("spree.no_products_found") %>
     </div>
   <% elsif params.key?(:keywords) %>
     <div data-hook="products_search_results_heading_results_found">
-      <h6 class="search-results-title"><%= Spree.t(:search_results, :keywords => h(params[:keywords])) %></h6>
+      <h6 class="search-results-title"><%= I18n.t("spree.search_results", keywords: h(params[:keywords])) %></h6>
     </div>
   <% end %>
 </div>

--- a/solidus_bootstrap/frontend/app/views/spree/shared/_search.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/shared/_search.html.erb
@@ -3,13 +3,13 @@
 <div class="form-group">
   <% cache(cache_key_for_taxons) do %>
     <%= select_tag :taxon,
-          options_for_select([[Spree.t(:all_departments), '']] +
+          options_for_select([[I18n.t("spree.all_departments"), '']] +
                                 @taxons.map {|t| [t.name, t.id]},
                                 @taxon ? @taxon.id : params[:taxon]), 'aria-label' => 'Taxon', class: "form-control" %>
   <% end %>
 </div>
 <div class="form-group">
-  <%= search_field_tag :keywords, params[:keywords], :placeholder => Spree.t(:search), class: "form-control" %>
+  <%= search_field_tag :keywords, params[:keywords], :placeholder => I18n.t("spree.search"), class: "form-control" %>
 </div>
-<%= submit_tag Spree.t(:search), :name => nil, class: "btn btn-success" %>
+<%= submit_tag I18n.t("spree.search"), :name => nil, class: "btn btn-success" %>
 <% end %>

--- a/solidus_bootstrap/frontend/app/views/spree/shared/_taxonomies.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/shared/_taxonomies.html.erb
@@ -2,7 +2,7 @@
 <nav id="taxonomies" class="sidebar-item" data-hook>
   <% @taxonomies.each do |taxonomy| %>
     <% cache [I18n.locale, taxonomy, max_level] do %>
-      <h4 class='taxonomy-root'><%= Spree.t(:shop_by_taxonomy, :taxonomy => taxonomy.name) %></h4>
+      <h4 class='taxonomy-root'><%= I18n.t("spree.shop_by_taxonomy", taxonomy: taxonomy.name) %></h4>
       <%= taxons_tree(taxonomy.root, @taxon, max_level) %>
     <% end %>
   <% end %>

--- a/solidus_bootstrap/frontend/spec/features/cart_spec.rb
+++ b/solidus_bootstrap/frontend/spec/features/cart_spec.rb
@@ -25,7 +25,7 @@ describe "Cart", type: :feature, inaccessible: true do
   it "does not error out with a 404 when GET'ing to /orders/populate" do
     visit '/orders/populate'
     within(".alert-error") do
-      expect(page).to have_content(Spree.t(:populate_get_error))
+      expect(page).to have_content(I18n.t("spree.populate_get_error"))
     end
   end
 

--- a/solidus_bootstrap/frontend/spec/features/checkout_spec.rb
+++ b/solidus_bootstrap/frontend/spec/features/checkout_spec.rb
@@ -375,7 +375,7 @@ describe "Checkout", type: :feature, inaccessible: true do
         click_on "Save and Continue"
 
         expect(Spree::Payment.count).to eq 0
-        expect(page).to have_content(Spree.t(:coupon_code_not_found))
+        expect(page).to have_content(I18n.t("spree.coupon_code_not_found"))
       end
     end
 
@@ -471,12 +471,12 @@ describe "Checkout", type: :feature, inaccessible: true do
     end
 
     it "displays a thank you message" do
-      expect(page).to have_content(Spree.t(:thank_you_for_your_order))
+      expect(page).to have_content(I18n.t("spree.thank_you_for_your_order"))
     end
 
     it "does not display a thank you message on that order future visits" do
       visit spree.order_path(order)
-      expect(page).to_not have_content(Spree.t(:thank_you_for_your_order))
+      expect(page).to_not have_content(I18n.t("spree.thank_you_for_your_order"))
     end
   end
 

--- a/solidus_bootstrap/frontend/spec/features/coupon_code_spec.rb
+++ b/solidus_bootstrap/frontend/spec/features/coupon_code_spec.rb
@@ -55,13 +55,13 @@ describe "Coupon code promotions", type: :feature, js: true do
       it "informs about an invalid coupon code" do
         fill_in "order_coupon_code", :with => "coupon_codes_rule_man"
         click_button "Save and Continue"
-        expect(page).to have_content(Spree.t(:coupon_code_not_found))
+        expect(page).to have_content(I18n.t("spree.coupon_code_not_found"))
       end
 
       it "can enter an invalid coupon code, then a real one" do
         fill_in "order_coupon_code", :with => "coupon_codes_rule_man"
         click_button "Save and Continue"
-        expect(page).to have_content(Spree.t(:coupon_code_not_found))
+        expect(page).to have_content(I18n.t("spree.coupon_code_not_found"))
         fill_in "order_coupon_code", :with => "onetwo"
         click_button "Save and Continue"
         expect(page).to have_content("Promotion (Onetwo)   -$10.00")
@@ -88,13 +88,13 @@ describe "Coupon code promotions", type: :feature, js: true do
       it "can enter a coupon code and receives success notification" do
         fill_in "order_coupon_code", :with => "onetwo"
         click_button "Update"
-        expect(page).to have_content(Spree.t(:coupon_code_applied))
+        expect(page).to have_content(I18n.t("spree.coupon_code_applied"))
       end
 
       it "can enter a promotion code with both upper and lower case letters" do
         fill_in "order_coupon_code", :with => "ONETwO"
         click_button "Update"
-        expect(page).to have_content(Spree.t(:coupon_code_applied))
+        expect(page).to have_content(I18n.t("spree.coupon_code_applied"))
       end
 
       it "informs the user about a coupon code which has exceeded its usage" do
@@ -103,7 +103,7 @@ describe "Coupon code promotions", type: :feature, js: true do
 
         fill_in "order_coupon_code", :with => "onetwo"
         click_button "Update"
-        expect(page).to have_content(Spree.t(:coupon_code_max_usage))
+        expect(page).to have_content(I18n.t("spree.coupon_code_max_usage"))
       end
 
       context "informs the user if the coupon code is not eligible" do
@@ -119,7 +119,7 @@ describe "Coupon code promotions", type: :feature, js: true do
 
           fill_in "order_coupon_code", :with => "onetwo"
           click_button "Update"
-          expect(page).to have_content(Spree.t(:item_total_less_than_or_equal, scope: [:eligibility_errors, :messages], amount: "$100.00"))
+          expect(page).to have_content(I18n.t("spree.eligibility_errors.messages.item_total_less_than_or_equal", amount: "$100.00""))
         end
       end
 
@@ -129,7 +129,7 @@ describe "Coupon code promotions", type: :feature, js: true do
         promotion.save!
         fill_in "order_coupon_code", :with => "onetwo"
         click_button "Update"
-        expect(page).to have_content(Spree.t(:coupon_code_expired))
+        expect(page).to have_content(I18n.t("spree.coupon_code_expired"))
       end
 
       context "calculates the correct amount of money saved with flat percent promotions" do

--- a/solidus_bootstrap/frontend/spec/features/order_spec.rb
+++ b/solidus_bootstrap/frontend/spec/features/order_spec.rb
@@ -68,7 +68,7 @@ describe 'orders', :type => :feature do
     visit spree.order_path(order)
 
     within '#order_summary' do
-      expect(page).to have_content("#{Spree.t(:order)} #{order.number}")
+      expect(page).to have_content("#{I18n.t('spree.order')} #{order.number}")
     end
   end
 end

--- a/solidus_bootstrap/frontend/spec/features/products_spec.rb
+++ b/solidus_bootstrap/frontend/spec/features/products_spec.rb
@@ -143,7 +143,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
       click_link product.name
       within("#product-price") do
         expect(page).to have_content variant.price
-        expect(page).not_to have_content Spree.t(:out_of_stock)
+        expect(page).not_to have_content I18n.t("spree.out_of_stock")
       end
     end
 
@@ -152,7 +152,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
 
       click_link product.name
       within("#product-price") do
-        expect(page).not_to have_content Spree.t(:out_of_stock)
+        expect(page).not_to have_content I18n.t("spree.out_of_stock")
       end
     end
 


### PR DESCRIPTION
`Spree.t()` and `Spree.translate()` are now deprecated in Solidus. This commit updates a large number of calls to `Spree.t()` to use `I18n.t()` instead.