### PR TITLE
Remove deprecated methods, method_type and discounted_amount

### DIFF
--- a/solidus_bootstrap/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/checkout/_payment.html.erb
@@ -49,7 +49,7 @@
       <% @order.available_payment_methods.each do |method| %>
         <li id="payment_method_<%= method.id %>" class="<%= 'last' if method == @order.available_payment_methods.last %>" data-hook>
           <fieldset>
-            <%= render :partial => "spree/checkout/payment/#{method.method_type}", :locals => { :payment_method => method } %>
+            <%= render :partial => "spree/checkout/payment/#{method.partial_name}", :locals => { :payment_method => method } %>
           </fieldset>
         </li>
       <% end %>

--- a/solidus_bootstrap/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/shared/_order_details.html.erb
@@ -110,7 +110,7 @@
     <% order.shipments.group_by { |s| s.selected_shipping_rate&.name }.each do |name, shipments| %>
       <tr class="total" data-hook='shipment-row'>
         <td colspan="4" align="right" class="text-muted"><%= I18n.t("spree.shipping") %>: <strong><%= name %></strong></td>
-        <td class="total"><span><%= Spree::Money.new(shipments.sum(&:discounted_cost), currency: order.currency).to_html %></span></td>
+        <td class="total"><span><%= Spree::Money.new(shipments.sum(&:total_before_tax), currency: order.currency).to_html %></span></td>
       </tr>
     <% end %>
   </tfoot>


### PR DESCRIPTION
These two methods are deprecated and will be removed from Solidus 3.0. https://github.com/solidusio/solidus/commit/8142809ef69e4e8b7902c14316bfcbf04265c574
https://github.com/solidusio/solidus/commit/5e1156aff808b510b1962e14debc7dea0bf57a63