### PR TITLE
Replace Spree::Address firstname and lastnames

### DIFF
--- a/solidus_auth_devise_bootstrap/spec/features/checkout_spec.rb
+++ b/solidus_auth_devise_bootstrap/spec/features/checkout_spec.rb
@@ -46,7 +46,15 @@ RSpec.feature 'Checkout', :js, type: :feature do
 
       str_addr = 'bill_address'
       select 'United States', from: "order_#{str_addr}_attributes_country_id"
-      %w(firstname lastname address1 city zipcode phone).each do |field|
+
+      if ::Spree.solidus_gem_version < Gem::Version.new('3.0.0')
+        fill_in "order_#{str_addr}_attributes_firstname", with: address.firstname
+        fill_in "order_#{str_addr}_attributes_lastname", with: address.lastname
+      else
+        fill_in "order_#{str_addr}_attributes_name", with: address.name
+      end
+
+      %w(address1 city zipcode phone).each do |field|
         fill_in "order_#{str_addr}_attributes_#{field}", with: "#{address.send(field)}"
       end
       select "#{address.state.name}", from: "order_#{str_addr}_attributes_state_id"
@@ -76,7 +84,15 @@ RSpec.feature 'Checkout', :js, type: :feature do
 
       str_addr = 'bill_address'
       select 'United States', from: "order_#{str_addr}_attributes_country_id"
-      %w(firstname lastname address1 city zipcode phone).each do |field|
+
+      if ::Spree.solidus_gem_version < Gem::Version.new('3.0.0')
+        fill_in "order_#{str_addr}_attributes_firstname", with: address.firstname
+        fill_in "order_#{str_addr}_attributes_lastname", with: address.lastname
+      else
+        fill_in "order_#{str_addr}_attributes_name", with: address.name
+      end
+
+      %w(address1 city zipcode phone).each do |field|
         fill_in "order_#{str_addr}_attributes_#{field}", with: "#{address.send(field)}"
       end
       select "#{address.state.name}", from: "order_#{str_addr}_attributes_state_id"
@@ -117,7 +133,15 @@ RSpec.feature 'Checkout', :js, type: :feature do
 
       str_addr = 'bill_address'
       select 'United States', from: "order_#{str_addr}_attributes_country_id"
-      %w(firstname lastname address1 city zipcode phone).each do |field|
+
+      if ::Spree.solidus_gem_version < Gem::Version.new('3.0.0')
+        fill_in "order_#{str_addr}_attributes_firstname", with: address.firstname
+        fill_in "order_#{str_addr}_attributes_lastname", with: address.lastname
+      else
+        fill_in "order_#{str_addr}_attributes_name", with: address.name
+      end
+
+      %w(address1 city zipcode phone).each do |field|
         fill_in "order_#{str_addr}_attributes_#{field}", with: "#{address.send(field)}"
       end
       select "#{address.state.name}", from: "order_#{str_addr}_attributes_state_id"
@@ -146,7 +170,15 @@ RSpec.feature 'Checkout', :js, type: :feature do
 
       str_addr = 'bill_address'
       select 'United States', from: "order_#{str_addr}_attributes_country_id"
-      %w(firstname lastname address1 city zipcode phone).each do |field|
+
+      if ::Spree.solidus_gem_version < Gem::Version.new('3.0.0')
+        fill_in "order_#{str_addr}_attributes_firstname", with: address.firstname
+        fill_in "order_#{str_addr}_attributes_lastname", with: address.lastname
+      else
+        fill_in "order_#{str_addr}_attributes_name", with: address.name
+      end
+
+      %w(address1 city zipcode phone).each do |field|
         fill_in "order_#{str_addr}_attributes_#{field}", with: "#{address.send(field)}"
       end
       select "#{address.state.name}", from: "order_#{str_addr}_attributes_state_id"

--- a/solidus_bootstrap/frontend/app/views/spree/address/_form.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/address/_form.html.erb
@@ -1,13 +1,20 @@
 <% address_id = address_type.chars.first %>
 <div class="inner" data-hook=<%="#{address_type}_inner" %>>
-  <p class="field" id=<%="#{address_id}firstname" %>>
-    <%= form.label :firstname, I18n.t("spree.first_name") %><span class="required">*</span><br />
-    <%= form.text_field :firstname, :class => 'form-control required' %>
-  </p>
-  <p class="field" id=<%="#{address_id}lastname" %>>
-    <%= form.label :lastname, I18n.t("spree.last_name") %><span class="required">*</span><br />
-    <%= form.text_field :lastname, :class => 'form-control required' %>
-  </p>
+  <% if ::Spree.solidus_gem_version >= Gem::Version.new('3.0.0') %>
+    <p class="field" id=<%="#{address_id}name" %>>
+    <%= form.label :name, I18n.t("spree.name") %><span class="required">*</span><br />
+    <%= form.text_field :name, :class => 'form-control required' %>
+    </p>
+  <% else %>
+    <p class="field" id=<%="#{address_id}firstname" %>>
+      <%= form.label :firstname, I18n.t("spree.first_name") %><span class="required">*</span><br />
+      <%= form.text_field :firstname, :class => 'form-control required' %>
+    </p>
+    <p class="field" id=<%="#{address_id}lastname" %>>
+      <%= form.label :lastname, I18n.t("spree.last_name") %><span class="required">*</span><br />
+      <%= form.text_field :lastname, :class => 'form-control required' %>
+    </p>
+  <% end %>
   <% if Spree::Config[:company] %>
     <p class="field" id=<%="#{address_id}company" %>>
       <%= form.label :company, I18n.t("spree.company") %><br />

--- a/solidus_bootstrap/frontend/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/solidus_bootstrap/frontend/app/views/spree/checkout/payment/_gateway.html.erb
@@ -4,7 +4,7 @@
 
   <p class="field">
     <%= label_tag "name_on_card_#{payment_method.id}", I18n.t("spree.name_on_card") %><span class="required">*</span><br />
-    <%= text_field_tag "#{param_prefix}[name]", "#{@order.billing_firstname} #{@order.billing_lastname}", { id: "name_on_card_#{payment_method.id}", :class => 'form-control required'} %>
+    <%= text_field_tag "#{param_prefix}[name]", "#{@order.billing_name}", { id: "name_on_card_#{payment_method.id}", :class => 'form-control required'} %>
   </p>
 
   <p class="field" data-hook="card_number">

--- a/solidus_bootstrap/frontend/spec/features/checkout_spec.rb
+++ b/solidus_bootstrap/frontend/spec/features/checkout_spec.rb
@@ -482,8 +482,14 @@ describe "Checkout", type: :feature, inaccessible: true do
 
   def fill_in_address
     address = "order_bill_address_attributes"
-    fill_in "#{address}_firstname", :with => "Ryan"
-    fill_in "#{address}_lastname", :with => "Bigg"
+
+    if ::Spree.solidus_gem_version < Gem::Version.new('3.0.0')
+       fill_in "#{address}_firstname", with: "Ryan"
+       fill_in "#{address}_lastname", with: "Bigg"
+    else
+       fill_in "#{address}_name", with: "Ryan Bigg"
+    end
+
     fill_in "#{address}_address1", :with => "143 Swan Street"
     fill_in "#{address}_city", :with => "Richmond"
     select "United States of America", :from => "#{address}_country_id"


### PR DESCRIPTION
In preparation for upgrading to Solidus 3.0, we added name to the forms and updated the specs.

